### PR TITLE
Fix TypeError with python 3.2

### DIFF
--- a/salt/client/ssh/__init__.py
+++ b/salt/client/ssh/__init__.py
@@ -168,11 +168,11 @@ do
                      PKG_CONFIG_PATH=$PKG_CONFIG_PATH \
                      "$py_cmd_path" -c \
                    'import base64;
-                   exec(base64.b64decode("""{{SSH_PY_CODE}}""").decode("utf-8"))'
+                   exec(base64.b64decode(b"""{{SSH_PY_CODE}}""").decode("utf-8"))'
         else
             exec $SUDO "$py_cmd_path" -c \
                    'import base64;
-                   exec(base64.b64decode("""{{SSH_PY_CODE}}""").decode("utf-8"))'
+                   exec(base64.b64decode(b"""{{SSH_PY_CODE}}""").decode("utf-8"))'
         fi
         exit 0
     else


### PR DESCRIPTION
        + SUDO=
        + [ -n sudo ]
        + SUDO=sudo
        + SUDO_USER=
        + [ sudo  ]
        + [  ]
        + [ sudo  ]
        + [ -n  ]
        + EX_PYTHON_INVALID=10
        + PYTHON_CMDS=python3 python27 python2.7 python26 python2.6 python2 python
        + command -v python3
        + python3 -c import sys; sys.exit(not (sys.version_info >= (2, 6)
        and sys.version_info[0] == 3));
        + python3 -c from __future__ import print_function;
        import sys; print(sys.executable);
        + py_cmd_path=/usr/bin/python3
        + command -v python3
        + cmdpath=/usr/bin/python3
        + file /usr/bin/python3
        + grep shell script
        + exec sudo /usr/bin/python3 -c import base64;
        exec(base64.b64decode("""IyBweWxpbnQ6IGRpc2FibGU9Vzk
...
      """).decode("utf-8"))
        Traceback (most recent call last):
          File "<string>", line 149, in <module>
          File "/usr/lib/python3.2/base64.py", line 83, in b64decode
            raise TypeError("expected bytes, not %s" % s.__class__.__name__)
        TypeError: expected bytes, not str

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
