### PR TITLE
Fix TypeError: 'NoneType'

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1458,7 +1458,7 @@ class State(object):
             if not isinstance(body, dict):
                 continue
             for state, run in six.iteritems(body):
-                if state.startswith('__'):
+                if state.startswith('__') or not run:
                     continue
                 for arg in run:
                     if isinstance(arg, dict):


### PR DESCRIPTION
16:13:10,772 [salt.client.ssh  ][ERROR   ][16487] TypeError encountered executing state.apply: 'NoneType' object is not iterable
Traceback (most recent call last):
  File "/Users/aaksenov/anaconda/envs/salt/lib/python3.5/site-packages/salt/client/ssh/__init__.py", line 970, in run_wfunc
    result = self.wfuncs[self.fun](*self.args, **self.kwargs)
  File "/Users/aaksenov/anaconda/envs/salt/lib/python3.5/site-packages/salt/client/ssh/wrapper/state.py", line 289,in apply_
    return highstate(**kwargs)
  File "/Users/aaksenov/anaconda/envs/salt/lib/python3.5/site-packages/salt/client/ssh/wrapper/state.py", line 313,in highstate
    chunks = st_.compile_low_chunks()
  File "/Users/aaksenov/anaconda/envs/salt/lib/python3.5/site-packages/salt/state.py", line 3487, in compile_low_chunks
    high, req_in_errors = self.state.requisite_in(high)
  File "/Users/aaksenov/anaconda/envs/salt/lib/python3.5/site-packages/salt/state.py", line 1463, in requisite_in
    for arg in run:
TypeError: 'NoneType' object is not iterable

if there is some sing like:

my-state:
  file.replace:

After fix:

my-server:
    - ID 'my-state' in SLS 'blabla' contains a short declaration (file.replace) with a trailing colon. When not passing any arguments to a state, the colon must be omitted.

### What does this PR do?

### What issues does this PR fix or reference?

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Tests written?

Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/latest/topics/development/contributing.html) for best practices.
